### PR TITLE
[feat] add core ECS types and manager

### DIFF
--- a/entity/entity.go
+++ b/entity/entity.go
@@ -1,0 +1,37 @@
+package entity
+
+import "fmt"
+
+type EntityId struct {
+	Index      uint32
+	Generation uint32
+}
+
+type Entity struct {
+	id   EntityId
+	mask ComponentMask
+}
+
+func (e Entity) ID() EntityId {
+	return e.id
+}
+
+func (e Entity) Mask() ComponentMask {
+	return e.mask
+}
+
+func (e *Entity) AddComponent(compID uint) {
+	e.mask.Set(compID)
+}
+
+func (e *Entity) RemoveComponent(compID uint) {
+	e.mask.Clear(compID)
+}
+
+func (e Entity) HasComponent(compID uint) bool {
+	return e.mask.Has(compID)
+}
+
+func (e Entity) String() string {
+	return fmt.Sprintf("Entity{Index:%d,Gen:%d}", e.id.Index, e.id.Generation)
+}

--- a/entity/manager.go
+++ b/entity/manager.go
@@ -1,0 +1,74 @@
+package entity
+
+import "sync"
+
+type EntityManager struct {
+	lock        sync.Mutex
+	generations []uint32 // per-index generation counter
+	freeList    []uint32
+	entities    map[uint32]Entity
+}
+
+func NewEntityManager(capEntites int) *EntityManager {
+	return &EntityManager{
+		generations: make([]uint32, capEntites),
+		freeList:    make([]uint32, 0, capEntites),
+		entities:    make(map[uint32]Entity, capEntites),
+	}
+}
+
+// Create allocates a new Entity, reusing a freed slot if available.
+// It is safe for concurrent use.
+func (mngr *EntityManager) Create() Entity {
+	mngr.lock.Lock()
+	defer mngr.lock.Unlock()
+
+	var idx uint32
+	if len(mngr.freeList) > 0 {
+		// reuse previosly freed index
+		idx = mngr.freeList[len(mngr.freeList)-1]
+		mngr.freeList = mngr.freeList[:len(mngr.freeList)-1]
+	} else {
+		idx = uint32(len(mngr.generations))
+		mngr.generations = append(mngr.generations, 0)
+	}
+	ent := Entity{id: EntityId{Index: idx, Generation: mngr.generations[idx]}}
+	mngr.entities[idx] = ent
+
+	return ent
+}
+
+// Destroy removes the given Entity if it is still valid,
+// increments its generation, and makes its slot available for reuse.
+// Invalid or already-destroyed Entities are ignored.
+func (mngr *EntityManager) Destroy(e Entity) {
+	mngr.lock.Lock()
+	defer mngr.lock.Unlock()
+
+	idx := e.id.Index
+
+	// early return if has been destroyed already or
+	// there is a generation mismatch
+	if mngr.generations[idx] != e.id.Generation {
+		return
+	}
+
+	// increase generation to invalidade old handles
+	mngr.generations[idx]++
+	delete(mngr.entities, idx)
+	mngr.freeList = append(mngr.freeList, idx)
+}
+
+// Get retrieves an Entity by its EntityId.
+// Returns false if the EntityId is stale or not present.
+func (mngr *EntityManager) Get(id EntityId) (Entity, bool) {
+	mngr.lock.Lock()
+	defer mngr.lock.Unlock()
+
+	if gen := mngr.generations[id.Index]; gen != id.Generation {
+		return Entity{}, false
+	}
+
+	ent, ok := mngr.entities[id.Index]
+	return ent, ok
+}

--- a/entity/mask.go
+++ b/entity/mask.go
@@ -1,0 +1,30 @@
+package entity
+
+const MaxComponents = 128
+
+// ComponentMask struct is a simple bitset with room for MaxComponents.
+// It's used to check, add and remove bits cheaply
+type ComponentMask struct {
+	bits [MaxComponents / 64]uint64
+}
+
+func (m *ComponentMask) Has(compId uint) bool {
+	word, bit := compId/64, compId%64
+	return (m.bits[word] & (1 << bit)) != 0
+}
+
+func (m *ComponentMask) Set(compId uint) {
+	word, bit := compId/64, compId%64
+	m.bits[word] |= (1 << bit)
+}
+
+func (m *ComponentMask) Clear(compId uint) {
+	word, bit := compId/64, compId%64
+	m.bits[word] &^= (1 << bit)
+}
+
+func (m *ComponentMask) Reset() {
+	for i := range m.bits {
+		m.bits[i] = 0
+	}
+}


### PR DESCRIPTION
# Description

- Introduce `EntityId` and `Entity` structs with `ID()/Mask()` accessors,` AddComponent/RemoveComponent/HasComponent` methods, and a `Stringer` implementation for easy debugging.
- Implement `EntityManager` with thread-safe `Create`, `Destroy`, and `Get` operations using a mutex, per-index generation counters, and a reusable free list.
- Add `ComponentMask` bitset (128-component capacity) with fast `Has`, `Set`, `Clear`, and `Reset` methods.