### PR TITLE
[feat]toml driven config|card related components|zone components

### DIFF
--- a/app/game.go
+++ b/app/game.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"log"
+
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/pedro-git-projects/go-mtg/game"
@@ -16,11 +18,12 @@ func setupStandardGame() *game.Game {
 	return g
 }
 
-func NewAppp() *App {
-	g := setupStandardGame()
-	return &App{
-		Game: g,
+func NewApp() *App {
+	g, err := game.SetupStandardGameFromTOML("game.toml")
+	if err != nil {
+		log.Fatal(err)
 	}
+	return &App{Game: g}
 }
 
 func (app *App) Update() error {
@@ -28,7 +31,7 @@ func (app *App) Update() error {
 }
 
 func (app *App) Draw(screen *ebiten.Image) {
-	ebitenutil.DebugPrint(screen, app.Game.PlayerStr())
+	ebitenutil.DebugPrint(screen, app.Game.LibraryStr())
 }
 
 func (app *App) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {

--- a/component/colorindicator.go
+++ b/component/colorindicator.go
@@ -1,0 +1,107 @@
+package component
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Color uint8
+
+const (
+	ColorColorless Color = 0
+	ColorBlack     Color = 1 << iota
+	ColorWhite
+	ColorGreen
+	ColorRed
+	ColorBlue
+)
+
+const AllColors = ColorBlack | ColorWhite | ColorGreen | ColorRed | ColorBlue
+
+var _orderedColors = []struct {
+	bit  Color
+	name string
+}{
+	{ColorWhite, "White"},
+	{ColorBlue, "Blue"},
+	{ColorBlack, "Black"},
+	{ColorRed, "Red"},
+	{ColorGreen, "Green"},
+}
+var _fmtColorNames = map[Color]string{
+	ColorBlack: "Black",
+	ColorWhite: "White",
+	ColorGreen: "Green",
+	ColorRed:   "Red",
+	ColorBlue:  "Blue",
+}
+
+func (c Color) Has(bit Color) bool     { return c&bit != 0 }
+func (c Color) Add(bit Color) Color    { return c | bit }
+func (c Color) Remove(bit Color) Color { return c &^ bit }
+func (c Color) IsColorless() bool      { return c == ColorColorless }
+
+func (c Color) String() string {
+	if c.IsColorless() {
+		return "Colorless"
+	}
+	var parts []string
+	for _, entry := range _orderedColors {
+		if c.Has(entry.bit) {
+			parts = append(parts, entry.name)
+		}
+	}
+	return strings.Join(parts, "+")
+}
+
+func (c Color) MarshalTOML() ([]byte, error) {
+	// emit as a quoted string, e.g. "Red+Blue"
+	return []byte(fmt.Appendf(nil, "%q", c.String())), nil
+}
+
+func (c *Color) UnmarshalTOML(v any) error {
+	switch val := v.(type) {
+	case string:
+		return c.parseFromString(val)
+	case []any:
+		// handle ["Red","Blue"] like JSON-array style
+		var parts []string
+		for _, e := range val {
+			if s, ok := e.(string); ok {
+				parts = append(parts, s)
+			} else {
+				return fmt.Errorf("invalid element %T in TOML color list", e)
+			}
+		}
+		return c.parseFromString(strings.Join(parts, "+"))
+	default:
+		return fmt.Errorf("unexpected type %T for Color in TOML", v)
+	}
+}
+
+func (c *Color) parseFromString(s string) error {
+	if s == "Colorless" {
+		*c = ColorColorless
+		return nil
+	}
+	var mask Color
+	for part := range strings.SplitSeq(s, "+") {
+		matched := false
+		for bit, name := range _fmtColorNames {
+			if name == part {
+				mask |= bit
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("unknown color %q in TOML", part)
+		}
+	}
+	*c = mask
+	return nil
+}
+
+type ColorIndicatorComponent struct {
+	Value Color `toml:"value"`
+}

--- a/component/component.go
+++ b/component/component.go
@@ -4,4 +4,21 @@ type ComponentId uint
 
 const (
 	LifeTotal ComponentId = iota
+	Name
+	ManaCost
+	Illustration
+	ColorIndicator
+	TypeLine
+	PowerAndToughness
+	Loyalty
+	Defense
+	HandModifier
+	LifeModifier
+	ExpansionSymbol
+	IllustrationCredit
+	LegalText
+	CollectorNumber
+	ZoneType
+	Contains
+	Owner
 )

--- a/component/contains.go
+++ b/component/contains.go
@@ -1,0 +1,46 @@
+package component
+
+import (
+	"fmt"
+
+	"github.com/pedro-git-projects/go-mtg/entity"
+)
+
+type ContainsComponent struct {
+	Value []entity.EntityId `toml:"contains" json:"value"`
+}
+
+// MarshalTOML emits this component as a TOML array of tables:
+// [[contains]]
+// index = X
+// generation = Y
+func (c ContainsComponent) MarshalTOML() ([]byte, error) {
+	var buf []byte
+	for _, id := range c.Value {
+		buf = fmt.Appendf(buf, "[[contains]]\n")
+		buf = fmt.Appendf(buf, "index = %d\n", id.Index)
+		buf = fmt.Appendf(buf, "generation = %d\n\n", id.Generation)
+	}
+	return buf, nil
+}
+
+func (c *ContainsComponent) UnmarshalTOML(v any) error {
+	arr, ok := v.([]any)
+	if !ok {
+		return fmt.Errorf("invalid type %T for ContainsComponent", v)
+	}
+	c.Value = make([]entity.EntityId, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return fmt.Errorf("invalid element %T in ContainsComponent", item)
+		}
+		idx, ok1 := m["index"].(int64)
+		gen, ok2 := m["generation"].(int64)
+		if !ok1 || !ok2 {
+			return fmt.Errorf("invalid index/generation in ContainsComponent element: %v", m)
+		}
+		c.Value = append(c.Value, entity.EntityId{Index: uint32(idx), Generation: uint32(gen)})
+	}
+	return nil
+}

--- a/component/lifetotal.go
+++ b/component/lifetotal.go
@@ -1,5 +1,26 @@
 package component
 
+import "fmt"
+
 type LifeTotalComponent struct {
-	Value int
+	Value int `toml:"value" json:"value"`
+}
+
+func (l LifeTotalComponent) MarshalTOML() ([]byte, error) {
+	data := fmt.Appendf(nil, "value = %d\n", l.Value)
+	return data, nil
+}
+
+func (l *LifeTotalComponent) UnmarshalTOML(data any) error {
+	switch v := data.(type) {
+	case int64:
+		l.Value = int(v)
+		return nil
+	case float64:
+		// TOML numeric can be float; convert safely
+		l.Value = int(v)
+		return nil
+	default:
+		return fmt.Errorf("invalid type %T for LifeTotalComponent", data)
+	}
 }

--- a/component/manacost.go
+++ b/component/manacost.go
@@ -1,0 +1,145 @@
+package component
+
+import (
+	"fmt"
+)
+
+type ManaCostComponent struct {
+	Generic   uint8 `toml:"generic,omitempty"`
+	Colorless uint8 `toml:"colorless,omitempty"`
+
+	White uint8 `toml:"white,omitempty"`
+	Blue  uint8 `toml:"blue,omitempty"`
+	Black uint8 `toml:"black,omitempty"`
+	Red   uint8 `toml:"red,omitempty"`
+	Green uint8 `toml:"green,omitempty"`
+
+	PhyWhite uint8 `toml:"phy_white,omitempty"` // {W/P}
+	PhyBlue  uint8 `toml:"phy_blue,omitempty"`  // {U/P}
+	PhyBlack uint8 `toml:"phy_black,omitempty"` // {B/P}
+	PhyRed   uint8 `toml:"phy_red,omitempty"`   // {R/P}
+	PhyGreen uint8 `toml:"phy_green,omitempty"` // {G/P}
+
+	HybridWU uint8 `toml:"hybrid_wu,omitempty"` // {W/U}
+	HybridWB uint8 `toml:"hybrid_wb,omitempty"` // {W/B}
+	HybridWG uint8 `toml:"hybrid_wg,omitempty"` // {W/G}
+	HybridWR uint8 `toml:"hybrid_wr,omitempty"` // {W/R}
+	HybridUB uint8 `toml:"hybrid_ub,omitempty"` // {U/B}
+	HybridUG uint8 `toml:"hybrid_ug,omitempty"` // {U/G}
+	HybridUR uint8 `toml:"hybrid_ur,omitempty"` // {U/R}
+	HybridBG uint8 `toml:"hybrid_bg,omitempty"` // {B/G}
+	HybridBR uint8 `toml:"hybrid_br,omitempty"` // {B/R}
+	HybridGR uint8 `toml:"hybrid_gr,omitempty"` // {G/R}
+}
+
+func (m ManaCostComponent) MarshalTOML() ([]byte, error) {
+	var buf []byte
+	// generic
+	if m.Generic > 0 {
+		buf = fmt.Appendf(buf, "generic = %d\n", m.Generic)
+	}
+	// colorless
+	if m.Colorless > 0 {
+		buf = fmt.Appendf(buf, "colorless = %d\n", m.Colorless)
+	}
+	// colored
+	if m.White > 0 {
+		buf = fmt.Appendf(buf, "white = %d\n", m.White)
+	}
+	if m.Blue > 0 {
+		buf = fmt.Appendf(buf, "blue  = %d\n", m.Blue)
+	}
+	if m.Black > 0 {
+		buf = fmt.Appendf(buf, "black = %d\n", m.Black)
+	}
+	if m.Red > 0 {
+		buf = fmt.Appendf(buf, "red   = %d\n", m.Red)
+	}
+	if m.Green > 0 {
+		buf = fmt.Appendf(buf, "green = %d\n", m.Green)
+	}
+	// phyrexian
+	if m.PhyWhite > 0 {
+		buf = fmt.Appendf(buf, "phy_white = %d\n", m.PhyWhite)
+	}
+	if m.PhyBlue > 0 {
+		buf = fmt.Appendf(buf, "phy_blue  = %d\n", m.PhyBlue)
+	}
+	if m.PhyBlack > 0 {
+		buf = fmt.Appendf(buf, "phy_black = %d\n", m.PhyBlack)
+	}
+	if m.PhyRed > 0 {
+		buf = fmt.Appendf(buf, "phy_red   = %d\n", m.PhyRed)
+	}
+	if m.PhyGreen > 0 {
+		buf = fmt.Appendf(buf, "phy_green = %d\n", m.PhyGreen)
+	}
+	// hybrid
+	if m.HybridWU > 0 {
+		buf = fmt.Appendf(buf, "hybrid_wu = %d\n", m.HybridWU)
+	}
+	if m.HybridWB > 0 {
+		buf = fmt.Appendf(buf, "hybrid_wb = %d\n", m.HybridWB)
+	}
+	if m.HybridWG > 0 {
+		buf = fmt.Appendf(buf, "hybrid_wg = %d\n", m.HybridWG)
+	}
+	if m.HybridWR > 0 {
+		buf = fmt.Appendf(buf, "hybrid_wr = %d\n", m.HybridWR)
+	}
+	if m.HybridUB > 0 {
+		buf = fmt.Appendf(buf, "hybrid_ub = %d\n", m.HybridUB)
+	}
+	if m.HybridUG > 0 {
+		buf = fmt.Appendf(buf, "hybrid_ug = %d\n", m.HybridUG)
+	}
+	if m.HybridUR > 0 {
+		buf = fmt.Appendf(buf, "hybrid_ur = %d\n", m.HybridUR)
+	}
+	if m.HybridBG > 0 {
+		buf = fmt.Appendf(buf, "hybrid_bg = %d\n", m.HybridBG)
+	}
+	if m.HybridBR > 0 {
+		buf = fmt.Appendf(buf, "hybrid_br = %d\n", m.HybridBR)
+	}
+	if m.HybridGR > 0 {
+		buf = fmt.Appendf(buf, "hybrid_gr = %d\n", m.HybridGR)
+	}
+	return buf, nil
+}
+
+func (m *ManaCostComponent) UnmarshalTOML(data any) error {
+	tbl, ok := data.(map[string]any)
+	if !ok {
+		return fmt.Errorf("invalid TOML type for ManaCostComponent: %T", data)
+	}
+	// helper to read int64 into uint8
+	read := func(key string, ptr *uint8) {
+		if v, ok := tbl[key].(int64); ok {
+			*ptr = uint8(v)
+		}
+	}
+	read("generic", &m.Generic)
+	read("colorless", &m.Colorless)
+	read("white", &m.White)
+	read("blue", &m.Blue)
+	read("black", &m.Black)
+	read("red", &m.Red)
+	read("green", &m.Green)
+	read("phy_white", &m.PhyWhite)
+	read("phy_blue", &m.PhyBlue)
+	read("phy_black", &m.PhyBlack)
+	read("phy_red", &m.PhyRed)
+	read("phy_green", &m.PhyGreen)
+	read("hybrid_wu", &m.HybridWU)
+	read("hybrid_wb", &m.HybridWB)
+	read("hybrid_wg", &m.HybridWG)
+	read("hybrid_wr", &m.HybridWR)
+	read("hybrid_ub", &m.HybridUB)
+	read("hybrid_ug", &m.HybridUG)
+	read("hybrid_ur", &m.HybridUR)
+	read("hybrid_bg", &m.HybridBG)
+	read("hybrid_br", &m.HybridBR)
+	read("hybrid_gr", &m.HybridGR)
+	return nil
+}

--- a/component/name.go
+++ b/component/name.go
@@ -1,0 +1,21 @@
+package component
+
+import "fmt"
+
+type NameComponent struct {
+	Value string `toml:"name" json:"value"`
+}
+
+func (n NameComponent) MarshalTOML() ([]byte, error) {
+	data := fmt.Appendf(nil, "name = %q\n", n.Value)
+	return data, nil
+}
+
+func (n *NameComponent) UnmarshalTOML(data any) error {
+	s, ok := data.(string)
+	if !ok {
+		return fmt.Errorf("invalid type %T for NameComponent", data)
+	}
+	n.Value = s
+	return nil
+}

--- a/component/owner.go
+++ b/component/owner.go
@@ -1,0 +1,30 @@
+package component
+
+import (
+	"fmt"
+
+	"github.com/pedro-git-projects/go-mtg/entity"
+)
+
+type OwnerComponent struct {
+	Value entity.EntityId `toml:"owner" json:"value"`
+}
+
+func (o OwnerComponent) MarshalTOML() ([]byte, error) {
+	buf := fmt.Appendf(nil, "owner = { index = %d, generation = %d }\n", o.Value.Index, o.Value.Generation)
+	return buf, nil
+}
+
+func (o *OwnerComponent) UnmarshalTOML(v any) error {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return fmt.Errorf("invalid type %T for OwnerComponent", v)
+	}
+	idx, ok1 := m["index"].(int64)
+	gen, ok2 := m["generation"].(int64)
+	if !ok1 || !ok2 {
+		return fmt.Errorf("invalid index/generation for OwnerComponent: %v", m)
+	}
+	o.Value = entity.EntityId{Index: uint32(idx), Generation: uint32(gen)}
+	return nil
+}

--- a/component/zonetype.go
+++ b/component/zonetype.go
@@ -1,0 +1,36 @@
+package component
+
+import "fmt"
+
+type Zone int
+
+const (
+	Library Zone = iota
+	Hand
+	Battlefield
+	Graveyard
+	Stack
+	Exile
+	CommandZone
+)
+
+type ZoneComponent struct {
+	Value Zone `toml:"zone" json:"value"`
+}
+
+func (z ZoneComponent) MarshalTOML() ([]byte, error) {
+	data := fmt.Appendf(nil, "zone = %d\n", z.Value)
+	return data, nil
+}
+
+func (z *ZoneComponent) UnmarshalTOML(data any) error {
+	switch v := data.(type) {
+	case int64:
+		z.Value = Zone(v)
+	case float64:
+		z.Value = Zone(int(v))
+	default:
+		return fmt.Errorf("invalid type %T for ZoneComponent", data)
+	}
+	return nil
+}

--- a/game.toml
+++ b/game.toml
@@ -1,0 +1,107 @@
+players = 2
+initial_life = 20
+
+[[libraries]]
+player = 1
+
+[[libraries.cards]]
+name = "Force of Negation"
+
+[libraries.cards.mana_cost]
+generic = 1
+blue = 2
+
+[libraries.cards.color_indicator]
+value = "Blue"
+
+[[libraries.cards]]
+name = "Assassin's Trophy"
+
+[libraries.cards.mana_cost]
+black = 1
+green = 1
+
+[libraries.cards.color_indicator]
+value = [
+    "Green",
+    "Black",
+]
+
+[[libraries.cards]]
+name = "Sol Ring"
+
+[libraries.cards.mana_cost]
+generic = 1
+
+[libraries.cards.color_indicator]
+value = "Colorless"
+
+[[libraries.cards]]
+name = "Rhystic Study"
+
+[libraries.cards.mana_cost]
+generic = 2
+blue    = 1
+
+[libraries.cards.color_indicator]
+value = "Blue"
+
+[[libraries.cards]]
+name = "Mana Drain"
+
+[libraries.cards.mana_cost]
+blue = 2
+
+[libraries.cards.color_indicator]
+value = "Blue"
+
+[[libraries]]
+player = 2
+
+[[libraries.cards]]
+name = "Lightning Bolt"
+
+[libraries.cards.mana_cost]
+red = 1
+
+[libraries.cards.color_indicator]
+value = "Red"
+
+[[libraries.cards]]
+name = "Demonic Tutor"
+
+[libraries.cards.mana_cost]
+generic = 1
+black   = 1
+
+[libraries.cards.color_indicator]
+value = "Green"
+
+[[libraries.cards]]
+name = "Thoughtseize"
+
+[libraries.cards.mana_cost]
+black = 1
+
+[libraries.cards.color_indicator]
+value = "Black"
+
+[[libraries.cards]]
+name = "Augury Adept"
+
+[libraries.cards.mana_cost]
+generic   = 1
+hybrid_wu = 2 
+
+[libraries.cards.color_indicator]
+value = "Blue+White"
+
+[[libraries.cards]]
+name = "Opt"
+
+[libraries.cards.mana_cost]
+blue = 1
+
+[libraries.cards.color_indicator]
+value = "Blue"
+

--- a/game/config.go
+++ b/game/config.go
@@ -1,0 +1,47 @@
+package game
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pedro-git-projects/go-mtg/component"
+)
+
+type LibraryConfig struct {
+	Player int          `toml:"player"` // 1-based index
+	Cards  []CardConfig `toml:"cards"`
+}
+
+type GameConfig struct {
+	Players     int             `toml:"players"`
+	InitialLife int             `toml:"initial_life"`
+	Libraries   []LibraryConfig `toml:"libraries"`
+}
+
+type CardConfig struct {
+	Name           string                            `toml:"name"`
+	ManaCost       component.ManaCostComponent       `toml:"mana_cost"`
+	ColorIndicator component.ColorIndicatorComponent `toml:"color_indicator"`
+}
+
+func LoadConfig(path string) (*GameConfig, error) {
+	var cfg GameConfig
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if _, err := toml.NewDecoder(f).Decode(&cfg); err != nil {
+		return nil, err
+	}
+	// sanity check: one [[libraries]] per player
+	if cfg.Players != len(cfg.Libraries) {
+		return nil, fmt.Errorf(
+			"players = %d but %d [[libraries]] entries",
+			cfg.Players, len(cfg.Libraries),
+		)
+	}
+	return &cfg, nil
+}

--- a/game/debug.go
+++ b/game/debug.go
@@ -1,0 +1,137 @@
+package game
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pedro-git-projects/go-mtg/component"
+)
+
+func (g *Game) PlayerStr() string {
+	g.lock.RLock()
+	defer g.lock.RUnlock()
+
+	var sb strings.Builder
+	for idx, p := range g.Players {
+		ltComp := g.lifeTotals[p.ID().Index]
+		sb.WriteString(fmt.Sprintf(
+			"Player %d (Entity%d): %d life\n",
+			idx+1,
+			p.ID().Index,
+			ltComp.Value,
+		))
+	}
+	return sb.String()
+}
+
+func (g *Game) LibraryStr() string {
+	g.lock.RLock()
+	defer g.lock.RUnlock()
+
+	var sb strings.Builder
+	for idx, player := range g.Players {
+		sb.WriteString(fmt.Sprintf(
+			"Player %d (Entity%d) Library:\n",
+			idx+1,
+			player.ID().Index,
+		))
+
+		found := false
+		for zoneIdx, zComp := range g.zoneTypes {
+			if zComp.Value != component.Library {
+				continue
+			}
+			if g.owners[zoneIdx].Value != player.ID() {
+				continue
+			}
+			found = true
+
+			for _, cardID := range g.contains[zoneIdx].Value {
+				name := g.names[cardID.Index].Value
+				cost := g.manaCosts[cardID.Index]
+				var parts []string
+				// generic mana (any color)
+				if cost.Generic > 0 {
+					parts = append(parts, fmt.Sprintf("{%d}", cost.Generic))
+				}
+				// colorless
+				for i := uint8(0); i < cost.Colorless; i++ {
+					parts = append(parts, "{C}")
+				}
+				// colored mana
+				for i := uint8(0); i < cost.White; i++ {
+					parts = append(parts, "{W}")
+				}
+				for i := uint8(0); i < cost.Blue; i++ {
+					parts = append(parts, "{U}")
+				}
+				for i := uint8(0); i < cost.Black; i++ {
+					parts = append(parts, "{B}")
+				}
+				for i := uint8(0); i < cost.Red; i++ {
+					parts = append(parts, "{R}")
+				}
+				for i := uint8(0); i < cost.Green; i++ {
+					parts = append(parts, "{G}")
+				}
+				// phyrexian
+				for i := uint8(0); i < cost.PhyWhite; i++ {
+					parts = append(parts, "{W/P}")
+				}
+				for i := uint8(0); i < cost.PhyBlue; i++ {
+					parts = append(parts, "{U/P}")
+				}
+				for i := uint8(0); i < cost.PhyBlack; i++ {
+					parts = append(parts, "{B/P}")
+				}
+				for i := uint8(0); i < cost.PhyRed; i++ {
+					parts = append(parts, "{R/P}")
+				}
+				for i := uint8(0); i < cost.PhyGreen; i++ {
+					parts = append(parts, "{G/P}")
+				}
+				// hybrid
+				for i := uint8(0); i < cost.HybridWU; i++ {
+					parts = append(parts, "{W/U}")
+				}
+				for i := uint8(0); i < cost.HybridWB; i++ {
+					parts = append(parts, "{W/B}")
+				}
+				for i := uint8(0); i < cost.HybridWG; i++ {
+					parts = append(parts, "{W/G}")
+				}
+				for i := uint8(0); i < cost.HybridWR; i++ {
+					parts = append(parts, "{W/R}")
+				}
+				for i := uint8(0); i < cost.HybridUB; i++ {
+					parts = append(parts, "{U/B}")
+				}
+				for i := uint8(0); i < cost.HybridUG; i++ {
+					parts = append(parts, "{U/G}")
+				}
+				for i := uint8(0); i < cost.HybridUR; i++ {
+					parts = append(parts, "{U/R}")
+				}
+				for i := uint8(0); i < cost.HybridBG; i++ {
+					parts = append(parts, "{B/G}")
+				}
+				for i := uint8(0); i < cost.HybridBR; i++ {
+					parts = append(parts, "{B/R}")
+				}
+				for i := uint8(0); i < cost.HybridGR; i++ {
+					parts = append(parts, "{G/R}")
+				}
+				costStr := strings.Join(parts, "")
+
+				color := g.colorIndicators[cardID.Index].Value.String()
+
+				sb.WriteString(fmt.Sprintf("  – %s %s [%s]\n", name, costStr, color))
+			}
+		}
+
+		if !found {
+			sb.WriteString("  – <no library found>\n")
+		}
+	}
+	return sb.String()
+}

--- a/game/game.go
+++ b/game/game.go
@@ -2,7 +2,6 @@ package game
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/pedro-git-projects/go-mtg/component"
@@ -10,34 +9,31 @@ import (
 )
 
 type Game struct {
-	EM         *entity.EntityManager
-	lifeTotals map[uint32]component.LifeTotalComponent
-	Players    []entity.Entity
-	lock       sync.RWMutex
-}
+	EM *entity.EntityManager
 
-func (g *Game) PlayerStr() string {
-	g.lock.RLock()
-	defer g.lock.RUnlock()
+	lifeTotals      map[uint32]component.LifeTotalComponent
+	names           map[uint32]component.NameComponent
+	manaCosts       map[uint32]component.ManaCostComponent
+	zoneTypes       map[uint32]component.ZoneComponent
+	owners          map[uint32]component.OwnerComponent
+	colorIndicators map[uint32]component.ColorIndicatorComponent
+	contains        map[uint32]component.ContainsComponent
 
-	var sb strings.Builder
-	for idx, p := range g.Players {
-		ltComp := g.lifeTotals[p.ID().Index]
-		sb.WriteString(fmt.Sprintf(
-			"Player %d (Entity%d): %d life\n",
-			idx+1,
-			p.ID().Index,
-			ltComp.Value,
-		))
-	}
-	return sb.String()
+	Players []entity.Entity
+	lock    sync.RWMutex
 }
 
 func NewGame(capacity int) *Game {
 	return &Game{
-		EM:         entity.NewEntityManager(capacity),
-		lifeTotals: make(map[uint32]component.LifeTotalComponent, 2),
-		Players:    make([]entity.Entity, 0, capacity),
+		EM:              entity.NewEntityManager(capacity),
+		lifeTotals:      make(map[uint32]component.LifeTotalComponent),
+		names:           make(map[uint32]component.NameComponent),
+		manaCosts:       make(map[uint32]component.ManaCostComponent),
+		zoneTypes:       make(map[uint32]component.ZoneComponent),
+		owners:          make(map[uint32]component.OwnerComponent),
+		contains:        make(map[uint32]component.ContainsComponent),
+		colorIndicators: make(map[uint32]component.ColorIndicatorComponent),
+		Players:         make([]entity.Entity, 0, capacity),
 	}
 }
 
@@ -52,9 +48,70 @@ func (g *Game) SpawnWithLifeTotal(initialLT int) entity.Entity {
 	return ent
 }
 
+func (g *Game) SpawnCard(cfg CardConfig) entity.Entity {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	c := g.EM.Create()
+	c.AddComponent(uint(component.Name))
+	c.AddComponent(uint(component.ManaCost))
+	c.AddComponent(uint(component.ColorIndicator))
+
+	g.names[c.ID().Index] = component.NameComponent{Value: cfg.Name}
+	g.manaCosts[c.ID().Index] = cfg.ManaCost
+	g.colorIndicators[c.ID().Index] = cfg.ColorIndicator
+
+	return c
+}
+
+func (g *Game) SpawnZone(zoneType component.Zone, owner entity.Entity, contents []entity.Entity) entity.Entity {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	z := g.EM.Create()
+	z.AddComponent(uint(component.ZoneType))
+	z.AddComponent(uint(component.Owner))
+	z.AddComponent(uint(component.Contains))
+
+	g.zoneTypes[z.ID().Index] = component.ZoneComponent{Value: zoneType}
+	g.owners[z.ID().Index] = component.OwnerComponent{Value: owner.ID()}
+
+	ids := make([]entity.EntityId, len(contents))
+	for i, e := range contents {
+		ids[i] = e.ID()
+	}
+	g.contains[z.ID().Index] = component.ContainsComponent{Value: ids}
+
+	return z
+}
+
 func (g *Game) SpawnPlayers(count int, initialLT int) {
 	for i := 0; i < count; i++ {
 		ent := g.SpawnWithLifeTotal(initialLT)
+		g.lock.Lock()
 		g.Players = append(g.Players, ent)
+		g.lock.Unlock()
+	}
+}
+
+func (g *Game) SpawnPlayer(initialLT int) entity.Entity {
+	ent := g.SpawnWithLifeTotal(initialLT)
+	g.lock.Lock()
+	g.Players = append(g.Players, ent)
+	g.lock.Unlock()
+	return ent
+}
+
+func (g *Game) SpawnPlayersWithLibraries(count, initialLT int, cardConfigs [][]CardConfig) {
+	if len(cardConfigs) != count {
+		panic(fmt.Sprintf("expected %d slices of CardConfig, got %d", count, len(cardConfigs)))
+	}
+	for i := 0; i < count; i++ {
+		player := g.SpawnPlayer(initialLT)
+
+		var cards []entity.Entity
+		for _, cfg := range cardConfigs[i] {
+			cards = append(cards, g.SpawnCard(cfg))
+		}
+
+		g.SpawnZone(component.Library, player, cards)
 	}
 }

--- a/game/setup.go
+++ b/game/setup.go
@@ -1,0 +1,23 @@
+package game
+
+func SetupStandardGameFromTOML(path string) (*Game, error) {
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// compute a rough capacity: players + total cards + one zone per player
+	totalCards := 0
+	for _, lib := range cfg.Libraries {
+		totalCards += len(lib.Cards)
+	}
+	g := NewGame(cfg.Players + totalCards + cfg.Players)
+
+	cardSlices := make([][]CardConfig, len(cfg.Libraries))
+	for i, lib := range cfg.Libraries {
+		cardSlices[i] = lib.Cards
+	}
+
+	g.SpawnPlayersWithLibraries(cfg.Players, cfg.InitialLife, cardSlices)
+	return g, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/pedro-git-projects/go-mtg
 
 go 1.24.5
 
-require github.com/hajimehoshi/ebiten/v2 v2.8.8
+require (
+	github.com/BurntSushi/toml v1.5.0
+	github.com/hajimehoshi/ebiten/v2 v2.8.8
+)
 
 require (
 	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 h1:Gk1XUEttOk0/hb6Tq3WkmutWa0ZLhNn/6fc6XZpM7tM=
 github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325/go.mod h1:ulhSQcbPioQrallSuIzF8l1NKQoD7xmMZc5NxzibUMY=
 github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	ebiten.SetWindowSize(640, 480)
 	ebiten.SetWindowTitle("Go MTG")
-	app := app.NewAppp()
+	app := app.NewApp()
 	if err := ebiten.RunGame(app); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

This PR overhauls our ECS initialization and serialization layers to be fully driven by a game.toml file, and extends our ManaCostComponent (and related game code) to cover colorless, phyrexian, and hybrid symbols. It also refactors component definitions for cleaner, zero-alloc TOML hooks, and stabilizes color ordering.

### 📝 What’s changed

#### 1. TOML-first configuration

* **`game/config.go` / `game/setup.go`**

  * Introduce `GameConfig` and `LibraryConfig` structs
  * `LoadConfig(path)`: parses and sanity-checks `players`, `initial_life`, and per-player `libraries` blocks
  * `SetupStandardGameFromTOML`: boots `Game` via `SpawnPlayersWithLibraries()`

* **`game.toml`**

  * Sample layout with multiple cards per library
  * Demonstrates generic, colorless, colored, phyrexian, hybrid, and multicolor indicators

#### 2. Extended / refactored components

* **`component/manacost.go`**

  * New fields: `Colorless`, `PhyWhite/Blue/…`, `HybridWU/WB/…`
  * Custom `MarshalTOML`+`UnmarshalTOML` for only non-zero keys

* **`component/colorindicator.go`**

  * Stable ordering of W/U/B/R/G in `Color.String()`
  * TOML hooks unchanged but now print consistently (e.g. `Black+Green`, never flicker)

* **New zero-alloc TOML components**

  * `NameComponent` (`name = "…"`)
  * `LifeTotalComponent` (`value = 20`)
  * `ZoneComponent` (`zone = 2`)
  * `ContainsComponent` (table-array `[[contains]] …`)
  * `OwnerComponent` (inline table `{index, generation}`)

#### 3. Game logic refactor

* **`game/game.go`**

  * Added `SpawnPlayer`, `SpawnCard`, `SpawnZone` helpers
  * `SpawnPlayersWithLibraries` now takes `[][]CardConfig` to support >1 card
  * Added mutex locking around all map/slice writes
  * `LibraryStr()` upgraded to print every mana symbol type: `{C}`, `{W}`, `{U/P}`, `{W/G}`, etc.

* **`app/game.go`**, **`main.go`**

  * Switch from hard-coded spawn to TOML-driven setup
  * Debug printing of both `PlayerStr()` and `LibraryStr()`

<img width="772" height="554" alt="image" src="https://github.com/user-attachments/assets/6ee437c0-048f-4172-bc39-e91c9d9aa832" />

